### PR TITLE
Refactor API auth and error handling, introduce utils

### DIFF
--- a/app/api/draft/create/route.ts
+++ b/app/api/draft/create/route.ts
@@ -1,79 +1,72 @@
 import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { Session } from 'next-auth'; // Import Session for sessionUser type
+import { withAuthenticatedSession } from '@/lib/apiUtils'; // Import the wrapper
 import prisma from '@/lib/prisma';
 
-export async function POST(request: Request) {
-  try {
-    // Check authentication
-    const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
-      return NextResponse.json(
-        { message: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+// Define the handler function that will be wrapped
+const createDraftHandler = async (sessionUser: Session['user'], request: Request) => {
+  // sessionUser is guaranteed by withAuthenticatedSession, so sessionUser.id can be used.
+  // A non-null assertion '!' is used for sessionUser.id for explicitness,
+  // assuming 'id' is always present on a valid sessionUser.
 
-    // Parse request body
-    const body = await request.json();
-    const { name, description, maxTeams, pickTimeSeconds, snakeFormat } = body;
+  // Parse request body
+  const body = await request.json();
+  const { name, description, maxTeams, pickTimeSeconds, snakeFormat } = body;
 
-    // Validate required fields
-    if (!name) {
-      return NextResponse.json(
-        { message: 'Room name is required' },
-        { status: 400 }
-      );
-    }
-
-    if (maxTeams < 2 || maxTeams > 32) {
-      return NextResponse.json(
-        { message: 'Maximum teams must be between 2 and 32' },
-        { status: 400 }
-      );
-    }
-
-    if (pickTimeSeconds < 30 || pickTimeSeconds > 300) {
-      return NextResponse.json(
-        { message: 'Pick time must be between 30 and 300 seconds' },
-        { status: 400 }
-      );
-    }
-
-    // Create draft room and add creator as first participant in a transaction
-    const draftRoom = await prisma.$transaction(async (tx) => {
-      // Create the draft room
-      const room = await tx.draftRoom.create({
-        data: {
-          name,
-          description,
-          maxTeams,
-          pickTimeSeconds,
-          snakeFormat,
-          createdBy: session.user.id,
-          status: 'PENDING',
-        },
-      });
-
-      // Add creator as first participant
-      await tx.draftParticipant.create({
-        data: {
-          userId: session.user.id,
-          draftRoomId: room.id,
-          pickOrder: 1,
-          isReady: true, // Creator is automatically ready
-        },
-      });
-
-      return room;
-    });
-
-    return NextResponse.json(draftRoom);
-  } catch (error) {
-    console.error('Failed to create draft room:', error);
+  // Validate required fields
+  if (!name) {
     return NextResponse.json(
-      { message: 'Failed to create draft room' },
-      { status: 500 }
+      { message: 'Room name is required' },
+      { status: 400 }
     );
   }
-} 
+
+  if (maxTeams < 2 || maxTeams > 32) {
+    return NextResponse.json(
+      { message: 'Maximum teams must be between 2 and 32' },
+      { status: 400 }
+    );
+  }
+
+  if (pickTimeSeconds < 30 || pickTimeSeconds > 300) {
+    return NextResponse.json(
+      { message: 'Pick time must be between 30 and 300 seconds' },
+      { status: 400 }
+    );
+  }
+
+  // Create draft room and add creator as first participant in a transaction
+  // The outer try-catch for generic errors is removed; withAuthenticatedSession handles it.
+  // Specific validation errors returning 400 are kept.
+  const draftRoom = await prisma.$transaction(async (tx) => {
+    // Create the draft room
+    const room = await tx.draftRoom.create({
+      data: {
+        name,
+        description,
+        maxTeams,
+        pickTimeSeconds,
+        snakeFormat,
+        createdBy: sessionUser.id!, // Use sessionUser.id
+        status: 'PENDING',
+      },
+    });
+
+    // Add creator as first participant
+    await tx.draftParticipant.create({
+      data: {
+        userId: sessionUser.id!, // Use sessionUser.id
+        draftRoomId: room.id,
+        pickOrder: 1,
+        isReady: true, // Creator is automatically ready
+      },
+    });
+
+    return room;
+  });
+
+  return NextResponse.json(draftRoom);
+};
+
+// Export the wrapped handler
+export const POST = withAuthenticatedSession(createDraftHandler);

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,36 +1,27 @@
-import { NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '../../../lib/auth';
-import prisma from '../../../lib/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+import { Session } from 'next-auth';
+import { withAuthenticatedSession } from '@/lib/apiUtils';
+import prisma from '@/lib/prisma'; // Adjusted import path for prisma
 
-export async function GET() {
-  try {
-    const session = await getServerSession(authOptions);
+// Define the handler function consistent with AuthenticatedApiHandler signature
+const getUserHandler = async (
+  sessionUser: Session['user'], 
+  request?: NextRequest // request might not be used in this specific handler but included for signature consistency
+) => {
+  // sessionUser is guaranteed to be present by withAuthenticatedSession.
+  // We assume 'email' is present on sessionUser based on existing logic.
+  // A non-null assertion '!' is used; if email can be null, error handling or type checks should be more robust.
+  const user = await prisma.user.findUnique({
+    where: { email: sessionUser.email! },
+  });
 
-    if (!session?.user?.email) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { email: session.user.email },
-    });
-
-    if (!user) {
-      return NextResponse.json(
-        { error: 'User not found' },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json(user);
-  } catch (error) {
-    console.error('Error fetching user:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
-} 
+
+  return NextResponse.json(user);
+  // Top-level try-catch is removed as withAuthenticatedSession handles generic errors.
+};
+
+// Wrap the handler with withAuthenticatedSession
+export const GET = withAuthenticatedSession(getUserHandler);

--- a/lib/apiUtils.ts
+++ b/lib/apiUtils.ts
@@ -1,0 +1,49 @@
+// This file contains utility functions for API route handlers.
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession, Session } from 'next-auth';
+import { authOptions } from '@/lib/auth'; // Adjusted path
+import { handleApiError } from './apiUtils';
+
+// Type for the handler function that will be wrapped
+type AuthenticatedApiHandler = (
+  sessionUser: Session['user'], // Using Session['user'] based on next-auth types and lib/auth.ts
+  request: NextRequest,
+  params?: { [key: string]: any }
+) => Promise<NextResponse> | NextResponse;
+
+export function handleApiError(error: unknown, status: number = 500) {
+  console.error('API Error:', error);
+
+  let errorMessage = 'An unexpected error occurred.';
+
+  if (error instanceof Error) {
+    errorMessage = status === 500 ? 'Internal server error' : error.message;
+  } else if (typeof error === 'string') {
+    errorMessage = status === 500 ? 'Internal server error' : error;
+  }
+  
+  if (status === 500) {
+    errorMessage = 'Internal server error';
+  }
+
+  return NextResponse.json({ error: errorMessage }, { status });
+}
+
+export function withAuthenticatedSession(handler: AuthenticatedApiHandler) {
+  return async (request: NextRequest, context?: { params: { [key: string]: any } }) => {
+    try {
+      const session = await getServerSession(authOptions);
+
+      // Check for session.user.id based on lib/auth.ts session callback
+      if (!session?.user?.id) { 
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      // Pass session.user, request, and context.params (if they exist) to the handler
+      return await handler(session.user, request, context?.params);
+    } catch (error) {
+      // Pass the error to handleApiError, which will determine the status and message
+      return handleApiError(error);
+    }
+  };
+}


### PR DESCRIPTION
I've introduced a new API utility module (`lib/apiUtils.ts`) with two main functions:
- `handleApiError`: This standardizes server-side error responses for API routes.
- `withAuthenticatedSession`: This is a higher-order function to streamline session checking and error handling for authenticated routes.

I've refactored the following API routes to use these utilities:
- `app/api/profile/route.ts` (GET, PUT)
- `app/api/user/route.ts` (GET)
- `app/api/draft/create/route.ts` (POST)
- `app/api/draft/list/route.ts` (GET)

This significantly reduces boilerplate code for session management and try-catch blocks in these routes, improving consistency and maintainability.

Further refactoring of other draft-related API routes ([roomId]/join, [roomId]/pick, [roomId]/state) using these utilities is planned.